### PR TITLE
refactor：移除无效的 GetItemInfo 兼容写法

### DIFF
--- a/Item.lua
+++ b/Item.lua
@@ -1,9 +1,18 @@
 
 local LibEvent = LibStub:GetLibrary("LibEvent.7000")
 
-local GetItemInfo = GetItemInfo or C_Item.GetItemInfo
-
 local addon = TinyTooltip
+
+local function GetItemInfoFromLink(linkOrId)
+    local name, link, quality, _, _, _, _, stackCount, _, texture = GetItemInfo(linkOrId)
+    if (not name) then return nil end
+    return {
+        itemLink = link,
+        itemQuality = quality,
+        itemStackCount = stackCount,
+        itemTexture = texture,
+    }
+end
 
 local function ColorBorder(tip, r, g, b)
     if (addon.db.item.coloredItemBorder) then
@@ -13,9 +22,9 @@ local function ColorBorder(tip, r, g, b)
     end
 end
 
-local function ItemIcon(tip, link)
+local function ItemIcon(tip, itemInfo)
     if (addon.db.item.showItemIcon) then
-        local texture = select(10, GetItemInfo(link))
+        local texture = itemInfo and itemInfo.itemTexture
         local text = addon:GetLine(tip,1):GetText()
         if (texture and not strfind(text, "^|T")) then
             addon:GetLine(tip,1):SetFormattedText("|T%s:16:16:0:0:32:32:2:30:2:30|t %s", texture, text)
@@ -23,9 +32,9 @@ local function ItemIcon(tip, link)
     end
 end
 
-local function ItemStackCount(tip, link)
+local function ItemStackCount(tip, itemInfo)
     if (addon.db.item.showStackCount) then
-        local stackCount = select(8, GetItemInfo(link))
+        local stackCount = itemInfo and itemInfo.itemStackCount
         if (stackCount and stackCount > 1) then
             local text = addon:GetLine(tip,1):GetText() .. format(" |cff00eeee/%s|r", stackCount)
             addon:GetLine(tip,1):SetText(text)
@@ -34,9 +43,10 @@ local function ItemStackCount(tip, link)
 end
 
 LibEvent:attachTrigger("tooltip:item", function(self, tip, link)
-    local quality = select(3, GetItemInfo(link)) or 0
+    local itemInfo = GetItemInfoFromLink(link)
+    local quality = (itemInfo and itemInfo.itemQuality) or 0
     local r, g, b = GetItemQualityColor(quality)
     ColorBorder(tip, r, g, b)
-    ItemStackCount(tip, link)
-    ItemIcon(tip, link)
+    ItemStackCount(tip, itemInfo)
+    ItemIcon(tip, itemInfo)
 end)


### PR DESCRIPTION
## 概述
- 移除 `GetItemInfo or C_Item.GetItemInfo` 的假兼容写法
- `C_Item.GetItemInfo` 接受 `ItemLocation`，与 `GetItemInfo(link)` 参数类型不兼容，fallback 无效

## 改进
- 提取 `GetItemInfoFromLink` 统一获取物品信息
- 原本 `ItemIcon`、`ItemStackCount`、`tooltip:item` 各自调用 `GetItemInfo`，现改为触发时调用一次，传递 `itemInfo` 给子函数
- 原本通过 `select(3/8/10, ...)` 基于返回值位置硬编码获取字段，现改为结构化 table（`itemInfo.itemQuality`），字段语义明确，更易维护和应对 API 变化