### PR TITLE
feat: Add option to hide unit frame right-click setup hint

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -31,6 +31,7 @@ addon.db = {
         bodyFontSize      = "default",
         bodyFontFlag      = "default",
         SavedVariablesPerCharacter = false,
+        hideUnitFrameHint = true,                  --隐藏头像框右键设置提示
     },
     unit = {
         player = {

--- a/Options.lua
+++ b/Options.lua
@@ -778,6 +778,7 @@ local options = {
         { keystring = "quest.coloredQuestBorder",   type = "checkbox" },
         { keystring = "general.alwaysShowIdInfo",   type = "checkbox" },
         { keystring = "general.SavedVariablesPerCharacter",   type = "checkbox" },
+        { keystring = "general.hideUnitFrameHint",  type = "checkbox" },
     },
     pc = {
         { keystring = "unit.player.showTarget",           type = "checkbox" },

--- a/Unit.lua
+++ b/Unit.lua
@@ -134,6 +134,8 @@ local function ShowBigFactionIcon(tip, config, raw)
     end
 end
 
+
+
 local function PlayerCharacter(tip, unit, config, raw)
     local specLine = GetOriginalSpecLine(tip, raw and raw.className)
     if (specLine) then
@@ -187,6 +189,23 @@ local function NonPlayerCharacter(tip, unit, config, raw)
     addon:AutoSetTooltipWidth(tip)
 end
 
+local function IsUnitTooltip(tt)
+    local owner = tt and tt:GetOwner()
+    if not owner then return false end
+    
+    -- 安全访问 owner.unit
+    local ok, unit = pcall(function() return owner.unit end)
+    if (ok and unit) then return true end
+    
+    -- 安全访问 GetAttribute
+    if (owner.GetAttribute) then
+        local okAttr, attrUnit = pcall(owner.GetAttribute, owner, "unit")
+        if (okAttr and attrUnit) then return true end
+    end
+    
+    return false
+end
+
 LibEvent:attachTrigger("tooltip:unit", function(self, tip, unit)
     if (not unit or not SafeBool(UnitExists, unit)) then return end
     local raw = addon:GetUnitInfo(unit)
@@ -196,6 +215,35 @@ LibEvent:attachTrigger("tooltip:unit", function(self, tip, unit)
         NonPlayerCharacter(tip, unit, addon.db.unit.npc, raw)
     end
 end)
+
+if (GameTooltip_AddInstructionLine) then
+    hooksecurefunc("GameTooltip_AddInstructionLine", function(tt, text)
+        if (not addon.db.general.hideUnitFrameHint) then return end
+        if (tt ~= GameTooltip) then return end
+        if (not UNIT_POPUP_RIGHT_CLICK or text ~= UNIT_POPUP_RIGHT_CLICK) then return end
+        if (not IsUnitTooltip(tt)) then return end
+        
+        local i = tt:NumLines()
+        local line = _G[tt:GetName() .. "TextLeft" .. i]
+        if (not line) then return end
+        
+        local tmpText = line:GetText()
+        if (issecretvalue and issecretvalue(tmpText)) then return end
+        if (tmpText ~= text) then return end
+        
+        line:SetText("")
+        line:Hide()
+        
+        local mLine = _G[tt:GetName() .. "TextLeft" .. (i - 1)]
+        if (mLine and mLine.GetText) then
+            local prevText = mLine:GetText()
+            if (not (issecretvalue and issecretvalue(prevText)) and prevText == " ") then
+                mLine:Hide()
+            end
+        end
+        tt:Show()
+    end)
+end
 
 addon.ColorUnitBorder = ColorBorder
 addon.ColorUnitBackground = ColorBackground

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -9,6 +9,7 @@ local T = {
     ["general.statusbarHide"]   = "Hide Status Bar",
     ["general.alwaysShowIdInfo"] = "Always Show Id Info (Otherwise hold down SHIFT/ALT)",
     ["general.skinMoreFrames"]   = "Skin More Frames |cffcccc33(need to /reload)|r",
+    ["general.hideUnitFrameHint"] = "Hide Unit Frame Right-Click Setup Hint",
     ["dropdown.inherit"]        = "|cffffee00inherit|r",
     ["dropdown.default"]        = "|cffaaaaaadefault|r",
     ["dropdown.cursor"]         = "|cff33ccffcursor|r",

--- a/locales/ruRU.lua
+++ b/locales/ruRU.lua
@@ -30,6 +30,7 @@ local T = {
     ["general.anchor.returnOnUnitFrame"]    = "Возвращ. на рамке юнита",
     ["general.alwaysShowIdInfo"]            = "Постоянное отображение ID (В противном случае, удерживайте нажатой клавишу alt/shift)",
     ["general.skinMoreFrames"]              = "Больше рамок скинов |cffcccc33(вступает в силу, после перегрузки)|r",
+    ["general.hideUnitFrameHint"]            = "Скрыть подсказку о настройке рамки юнита",
    
     ["item.coloredItemBorder"]              = "Цвет границы предмета",
     ["item.showItemIcon"]                   = "Отображение значка предмета",

--- a/locales/zhCN.lua
+++ b/locales/zhCN.lua
@@ -31,6 +31,7 @@ local T = {
     ["general.alwaysShowIdInfo"]            = "始终显示id信息(关闭后按住alt/shift显示)",
     ["general.skinMoreFrames"]              = "样式应用于更多框架 |cffcccc33(重载生效)|r",
     ["general.SavedVariablesPerCharacter"]  = "为每个角色保存独立配置",
+    ["general.hideUnitFrameHint"]            = "隐藏头像框右键设置提示",
     
     ["item.coloredItemBorder"]              = "物品边框染色",
     ["item.showItemIcon"]                   = "显示物品图标",

--- a/locales/zhTW.lua
+++ b/locales/zhTW.lua
@@ -30,6 +30,7 @@ local T = {
     ["general.alwaysShowIdInfo"]            = "始終顯示id信息(關閉後按住alt/shift顯示)",
     ["general.skinMoreFrames"]              = "樣式應用于更多框架 |cffcccc33(重載生效)|r",
     ["general.SavedVariablesPerCharacter"]  = "為每個角色保存獨立配置",
+    ["general.hideUnitFrameHint"]            = "隱藏頭像框右鍵設置提示",
     
     ["item.coloredItemBorder"]              = "物品邊框染色",
     ["item.showItemIcon"]                   = "顯示物品圖標",


### PR DESCRIPTION
- Add general.hideUnitFrameHint option to config
- Hook GameTooltip_AddInstructionLine to remove UNIT_POPUP_RIGHT_CLICK text
- Set _isUnitTooltip marker in ProcessInfo and OnTooltipSetUnit events
- Add duplicate processing protection with _hintLineHidden flag
- Hide empty spacing line before hint if present
- Add UI checkbox in general options panel
- Add localization strings for all supported languages