### PR TITLE
Set tooltip width before check showing FactionIcon can solve the problem.

### DIFF
--- a/Unit.lua
+++ b/Unit.lua
@@ -152,6 +152,9 @@ local function PlayerCharacter(tip, unit, config, raw)
     ColorBorder(tip, config, raw)
     ColorBackground(tip, config, raw)
     GrayForDead(tip, config, unit)
+    if (addon.AutoSetTooltipWidth) then
+        addon:AutoSetTooltipWidth(tip)
+    end
     ShowBigFactionIcon(tip, config, raw)
 end
 


### PR DESCRIPTION
Problem caused due to not calculating tooltip width when not ShowingFactionIcon && Not UnitFrame mouseover.