### PR TITLE
protect nineslice call to avoid bad self error

### DIFF
--- a/General.lua
+++ b/General.lua
@@ -145,7 +145,7 @@ LibEvent:attachTrigger("tooltip:cleared, tooltip:hide", function(self, tip)
     LibEvent:trigger("tooltip.style.background", tip, unpack(addon.db.general.background))
     if (tip.BigFactionIcon) then tip.BigFactionIcon:Hide() end
     if (tip.SetBackdrop) then tip:SetBackdrop(nil) end
-    if (tip.NineSlice) then tip.NineSlice:Hide() end
+    if (tip.NineSlice and addon.SafeHideNineSlice) then addon.SafeHideNineSlice(tip) end
 end)
 
 LibEvent:attachTrigger("tooltip:show", function(self, tip)


### PR DESCRIPTION
Couldn't reproduce the error but tried to check onHide() availability before calling onHide()